### PR TITLE
docs: add GitHub link for contributor Lucas Borges

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -8,7 +8,7 @@
 - [Alejandra Klachquin](https://github.com/alejandraklachquin)
 - Avner Gonçalves
 - [Laura Panzariello](https://github.com/laurapanzariello)
-- Lucas Borges
+- [Lucas Borges](https://github.com/barizonlucas)
 - Mauricio Leoncio dos Santos
 - Mateus Constanzo
 - [Silvano Buback](https://github.com/snbuback)


### PR DESCRIPTION
Adding my GitHub profile link to my contributor entry in AUTHORS.md.

Other contributors already have their profiles linked in the same format (`[Name](https://github.com/username)`). This just adds the link for my entry, which was previously plain text.